### PR TITLE
fix: align Pebble model compiler artifacts

### DIFF
--- a/framework/quant/core/importer.py
+++ b/framework/quant/core/importer.py
@@ -74,8 +74,7 @@ def _rax_pack() -> Path:
     root = os.environ.get("BUDDY_MLIR_BUILD_DIR")
     if root is None:
         raise RuntimeError("BUDDY_MLIR_BUILD_DIR is required")
-    build = Path(root)
-    return build.parent / "cores" / build.name / "bin" / "rax-pack"
+    return Path(root) / "bin" / "rax-pack"
 
 
 def _form_mega_kernels(graph, parameter_names, arrays, weight_scales, calibration):

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -8,7 +8,20 @@ if(NOT DEFINED ENV{BUDDY_MLIR_BUILD_DIR})
     "BUDDY_MLIR_BUILD_DIR is not set. Enter the nix develop shell so "
     "sourceme.sh is loaded, then re-run cmake.")
 endif()
-set(BUDDY_MLIR_DIR $ENV{BUDDY_MLIR_BUILD_DIR}/..)
+# The parent Buckyball workload project already points BUDDY_MLIR_DIR at the
+# buddy-mlir source tree.  Preserve it: per-chip compiler builds live under
+# build/<chip>, so deriving the source as BUDDY_MLIR_BUILD_DIR/.. would resolve
+# to the build directory instead.
+if(NOT DEFINED BUDDY_MLIR_DIR)
+  get_filename_component(_BUDDY_BUILD_PARENT
+    "$ENV{BUDDY_MLIR_BUILD_DIR}/.." ABSOLUTE)
+  if(EXISTS "${_BUDDY_BUILD_PARENT}/llvm/mlir")
+    set(BUDDY_MLIR_DIR "${_BUDDY_BUILD_PARENT}")
+  else()
+    get_filename_component(BUDDY_MLIR_DIR
+      "${_BUDDY_BUILD_PARENT}/.." ABSOLUTE)
+  endif()
+endif()
 set(BUDDY_BINARY_DIR $ENV{BUDDY_MLIR_BUILD_DIR}/bin)
 set(RISCV_GNU_TOOLCHAIN $ENV{RISCV})
 

--- a/models/models/LeNet/buddy-lenet-main.cpp
+++ b/models/models/LeNet/buddy-lenet-main.cpp
@@ -33,7 +33,7 @@
 #include <vector>
 
 constexpr size_t ParamsSize = 236;
-constexpr size_t WeightsSize = 44190;
+constexpr size_t WeightsSize = 45224;
 constexpr size_t MnistCount = 10000;
 constexpr size_t MnistPixels = 28 * 28;
 const std::string ImgName = "8.bmp";


### PR DESCRIPTION
## Summary

- resolve `rax-pack` from the per-chip compiler build directory
- preserve the Buddy source path when the build directory is `build/<chip>`
- use the generated 45,224-byte packed LeNet weight payload size

## Validation

- Python syntax parsing passed
- `git diff --check`
- generated and packaged `weights.i8` sizes are both 45,224 bytes