### PR TITLE
fix: align Pebble model compiler artifacts

### DIFF
--- a/framework/quant/core/importer.py
+++ b/framework/quant/core/importer.py
@@ -76,8 +76,7 @@ def _rax_pack() -> Path:
     root = os.environ.get("BUDDY_MLIR_BUILD_DIR")
     if root is None:
         raise RuntimeError("BUDDY_MLIR_BUILD_DIR is required")
-    build = Path(root)
-    return build.parent / "cores" / build.name / "bin" / "rax-pack"
+    return Path(root) / "bin" / "rax-pack"
 
 
 def _form_mega_kernels(graph, parameter_names, arrays, weight_scales, calibration):

--- a/framework/quant/core/importer.py
+++ b/framework/quant/core/importer.py
@@ -73,10 +73,7 @@ def fold_batch_norms(model: torch.nn.Module) -> None:
 
 
 def _rax_pack() -> Path:
-    root = os.environ.get("BUDDY_MLIR_BUILD_DIR")
-    if root is None:
-        raise RuntimeError("BUDDY_MLIR_BUILD_DIR is required")
-    return Path(root) / "bin" / "rax-pack"
+    return Path(os.environ["BUDDY_MLIR_BUILD_DIR"]) / "bin" / "rax-pack"
 
 
 def _form_mega_kernels(graph, parameter_names, arrays, weight_scales, calibration):

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -8,7 +8,20 @@ if(NOT DEFINED ENV{BUDDY_MLIR_BUILD_DIR})
     "BUDDY_MLIR_BUILD_DIR is not set. Enter the nix develop shell so "
     "sourceme.sh is loaded, then re-run cmake.")
 endif()
-set(BUDDY_MLIR_DIR $ENV{BUDDY_MLIR_BUILD_DIR}/..)
+# The parent Buckyball workload project already points BUDDY_MLIR_DIR at the
+# buddy-mlir source tree.  Preserve it: per-chip compiler builds live under
+# build/<chip>, so deriving the source as BUDDY_MLIR_BUILD_DIR/.. would resolve
+# to the build directory instead.
+if(NOT DEFINED BUDDY_MLIR_DIR)
+  get_filename_component(_BUDDY_BUILD_PARENT
+    "$ENV{BUDDY_MLIR_BUILD_DIR}/.." ABSOLUTE)
+  if(EXISTS "${_BUDDY_BUILD_PARENT}/llvm/mlir")
+    set(BUDDY_MLIR_DIR "${_BUDDY_BUILD_PARENT}")
+  else()
+    get_filename_component(BUDDY_MLIR_DIR
+      "${_BUDDY_BUILD_PARENT}/.." ABSOLUTE)
+  endif()
+endif()
 set(BUDDY_BINARY_DIR $ENV{BUDDY_MLIR_BUILD_DIR}/bin)
 set(RISCV_GNU_TOOLCHAIN $ENV{RISCV})
 

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -8,19 +8,8 @@ if(NOT DEFINED ENV{BUDDY_MLIR_BUILD_DIR})
     "BUDDY_MLIR_BUILD_DIR is not set. Enter the nix develop shell so "
     "sourceme.sh is loaded, then re-run cmake.")
 endif()
-# The parent Buckyball workload project already points BUDDY_MLIR_DIR at the
-# buddy-mlir source tree.  Preserve it: per-chip compiler builds live under
-# build/<chip>, so deriving the source as BUDDY_MLIR_BUILD_DIR/.. would resolve
-# to the build directory instead.
 if(NOT DEFINED BUDDY_MLIR_DIR)
-  get_filename_component(_BUDDY_BUILD_PARENT
-    "$ENV{BUDDY_MLIR_BUILD_DIR}/.." ABSOLUTE)
-  if(EXISTS "${_BUDDY_BUILD_PARENT}/llvm/mlir")
-    set(BUDDY_MLIR_DIR "${_BUDDY_BUILD_PARENT}")
-  else()
-    get_filename_component(BUDDY_MLIR_DIR
-      "${_BUDDY_BUILD_PARENT}/.." ABSOLUTE)
-  endif()
+  message(FATAL_ERROR "BUDDY_MLIR_DIR is not set")
 endif()
 set(BUDDY_BINARY_DIR $ENV{BUDDY_MLIR_BUILD_DIR}/bin)
 set(RISCV_GNU_TOOLCHAIN $ENV{RISCV})


### PR DESCRIPTION
## Summary

- resolve rax-pack directly from BUDDY_MLIR_BUILD_DIR/bin
- require the parent Buckyball build to provide BUDDY_MLIR_DIR
- retain the 45,224-byte packed LeNet payload size already present on the Buckyball branch

## Validation

- Python syntax parsing passed
- CMake accepted the parent-provided compiler paths
- git diff --check passed